### PR TITLE
changed ga4gh_client declaration to default api_location to "" rather than "/ga4gh"

### DIFF
--- a/R/ga4gh_client.R
+++ b/R/ga4gh_client.R
@@ -32,7 +32,7 @@
 #'
 #' @export
 
-ga4gh_client <- function(server, port = NULL, api_location = "/ga4gh", log_level = 0, authentication_key = "", page_size = 10) {
+ga4gh_client <- function(server, port = NULL, api_location = "", log_level = 0, authentication_key = "", page_size = 10) {
   api_url <- server
   if(!is.null(port)) {
     api_url <- paste0(api_url, ":", port)


### PR DESCRIPTION
 It might be nice to have the api_location in the ga4gh_client declaration default to “” rather than "/ga4gh”. This might make it easier considering the "/ga4gh” default results in this: 

> library(Rga4gh)
Loading required package: httr
> library(magrittr)
> ref_client <- ga4gh_client("http://1kgenomes.ga4gh.org")
> datasets <- ref_client %>% search_datasets() %>% content()
> datasets
$errorCode
[1] 523835337

$message
[1] "The request path was not found"
